### PR TITLE
Add simple unit tests to k2pix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 __pycache__
 *.pyc
 .DS_Store
+.cache
+.eggs
+*.egg-info

--- a/k2pix/.travis.yml
+++ b/k2pix/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+- "2.7"
+- "3.5"
+- "3.6"
+install:
+- pip install -r requirements.txt
+- python setup.py install
+script:
+- py.test

--- a/k2pix/requirements.txt
+++ b/k2pix/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+matplotlib
+astropy
+imageio
+tqdm
+pyketools
+astroquery

--- a/k2pix/tests/test_imports.py
+++ b/k2pix/tests/test_imports.py
@@ -1,0 +1,16 @@
+"""Simple import tests to guard against syntax errors."""
+import pytest
+
+def test_imports():
+    """A simple test to make sure k2pix's key functions can be imported."""
+    from ..main import k2pix
+    from ..tpf import TargetPixelFile
+    from ..figure import K2Fig
+
+
+def test_main_function():
+    """The `k2pix` command-line tool calls the function `k2pix.main.k2pix()`,
+    let's make sure it runs!"""
+    from ..main import k2pix
+    with pytest.raises(SystemExit):
+        k2pix()


### PR DESCRIPTION
This PR adds the first simple unit tests to `k2pix`.  They can be run by running `py.test` in the repository.

Feel free to add additional unit tests or a travis file by pushing to this branch.